### PR TITLE
Improve scraper defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,44 @@
 # Web_Scrapin
 
-# Author: [Your Name]
+This project includes a small Python script for scraping a webpage and downloading files linked on that page. It can also display the contents of a local file. Scraped data is saved in the `scrapped` folder as PDF, JSON and CSV files.
+
+## Requirements
+
+Install dependencies with pip:
+
+```bash
+python -m pip install -r requirements.txt
+```
+
+If `uvicorn` is not found after installation, you can run it via the Python
+module command:
+
+```bash
+python -m uvicorn api:app --reload
+```
+
+## Usage
+
+### Scrape a webpage (CLI)
+
+```bash
+python scraper.py --url https://example.com
+```
+
+This command saves the HTML of the page to the `scrapped` directory and downloads any linked files (PDF, images, spreadsheets, JSON, etc.) into the same folder. The page text is saved as `page.pdf`, `page.json` and `page.csv`.
+
+### Display a local file (CLI)
+
+```bash
+python scraper.py --file path/to/file.txt
+```
+
+This prints the file contents to the terminal and stores them in the `scrapped` folder. Use `--output DIR` to specify a different directory if needed.
+
+### Run the API
+
+You can also start a small FastAPI server which exposes endpoints for uploading a URL or a file. Swagger UI documentation is available at `/docs` once the server is running.
+
+```bash
+python -m uvicorn api:app --reload
+```

--- a/api.py
+++ b/api.py
@@ -1,0 +1,23 @@
+from fastapi import FastAPI, UploadFile, File
+import shutil
+import os
+from scraper import download_webpage, store_content, SCRAP_DIR
+
+app = FastAPI(title="Web and File Scraper")
+
+@app.post("/scrape/url")
+async def scrape_url(url: str):
+    html_path, files, text = download_webpage(url, SCRAP_DIR)
+    return {"html": html_path, "files": files}
+
+@app.post("/scrape/file")
+async def scrape_file(file: UploadFile = File(...)):
+    os.makedirs(SCRAP_DIR, exist_ok=True)
+    dest_path = os.path.join(SCRAP_DIR, file.filename)
+    with open(dest_path, "wb") as f:
+        shutil.copyfileobj(file.file, f)
+    with open(dest_path, "r", encoding="utf-8", errors="ignore") as f_in:
+        content = f_in.read()
+    base_name = os.path.splitext(file.filename)[0]
+    store_content(content, base_name, SCRAP_DIR)
+    return {"file_path": dest_path}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+requests
+beautifulsoup4
+fastapi
+uvicorn
+fpdf

--- a/scraper.py
+++ b/scraper.py
@@ -1,0 +1,103 @@
+import argparse
+import os
+import re
+from urllib.parse import urljoin
+
+import requests
+from bs4 import BeautifulSoup
+from fpdf import FPDF
+import json
+import csv
+
+# Directory where scraped information is stored by default
+SCRAP_DIR = "scrapped"
+
+# Exported symbols
+__all__ = [
+    "download_webpage",
+    "print_file",
+    "store_content",
+]
+
+
+def store_content(text: str, name: str, output_dir: str):
+    """Save scraped text to PDF, JSON, and CSV."""
+    os.makedirs(output_dir, exist_ok=True)
+
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_font("Arial", size=12)
+    for line in text.splitlines():
+        pdf.multi_cell(0, 10, txt=line)
+    pdf.output(os.path.join(output_dir, f"{name}.pdf"))
+
+    with open(os.path.join(output_dir, f"{name}.json"), "w", encoding="utf-8") as f_json:
+        json.dump({"content": text}, f_json, ensure_ascii=False, indent=2)
+
+    with open(os.path.join(output_dir, f"{name}.csv"), "w", newline="", encoding="utf-8") as f_csv:
+        writer = csv.writer(f_csv)
+        writer.writerow(["content"])
+        for line in text.splitlines():
+            writer.writerow([line])
+
+
+def download_webpage(url: str, output_dir: str = SCRAP_DIR):
+    os.makedirs(output_dir, exist_ok=True)
+    response = requests.get(url)
+    response.raise_for_status()
+    html_path = os.path.join(output_dir, "page.html")
+    with open(html_path, "w", encoding="utf-8") as f:
+        f.write(response.text)
+
+    soup = BeautifulSoup(response.text, "html.parser")
+    page_text = soup.get_text(separator="\n")
+    file_links = []
+    for a in soup.find_all("a", href=True):
+        href = a["href"]
+        if re.search(r"\.(pdf|docx?|xlsx?|csv|jpg|png|gif|txt|json)$", href, re.IGNORECASE):
+            file_links.append(href)
+
+    downloaded_files = []
+    for link in file_links:
+        file_url = link
+        if not re.match(r"^https?://", file_url):
+            file_url = urljoin(url, file_url)
+        file_name = os.path.basename(file_url.split("?")[0])
+        out_path = os.path.join(output_dir, file_name)
+        r = requests.get(file_url)
+        with open(out_path, "wb") as f:
+            f.write(r.content)
+        downloaded_files.append(out_path)
+
+    store_content(page_text, "page", output_dir)
+    return html_path, downloaded_files, page_text
+
+
+def print_file(file_path: str, output_dir: str = SCRAP_DIR):
+    with open(file_path, "r", encoding="utf-8", errors="ignore") as f:
+        content = f.read()
+    print(content)
+    base_name = os.path.splitext(os.path.basename(file_path))[0]
+    store_content(content, base_name, output_dir)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Simple web and file scraper")
+    parser.add_argument("--url", help="URL of the web page to scrape")
+    parser.add_argument("--file", help="Local file path to display")
+    parser.add_argument("--output", default=SCRAP_DIR, help="Directory to save scraped data")
+    args = parser.parse_args()
+
+    if args.url:
+        html_path, files, _text = download_webpage(args.url, args.output)
+        print(f"Saved HTML to {html_path}")
+        if files:
+            print("Downloaded files:")
+            for path in files:
+                print(f" - {path}")
+    if args.file:
+        print_file(args.file, args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- use a constant output directory for both the CLI and API
- expose `SCRAP_DIR` and exported functions from `scraper`
- document the default directory in README
- make API import the constant from `scraper`

## Testing
- `python -m py_compile scraper.py api.py`


------
https://chatgpt.com/codex/tasks/task_e_6877409687048328a53ef0c4db609179